### PR TITLE
Fix incorrect User#authenticate comparison

### DIFF
--- a/src/models/user.cr
+++ b/src/models/user.cr
@@ -83,6 +83,6 @@ class User < ApplicationRecord
   end
 
   def authenticate(given_password)
-    self if Crypto::Bcrypt::Password.new(password_digest) == given_password
+    self if Crypto::Bcrypt::Password.new(password_digest).verify(given_password)
   end
 end


### PR DESCRIPTION
Authenticate is supposed to compare the digest hash to the given password, but instead compares the raw given_password. #verify should be used instead.
Ref: https://crystal-lang.org/api/0.35.0/Crypto/Bcrypt/Password.html#verify(password:String):Bool-instance-method